### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Would you rather compare 60 hexadecimal characters or only 30 emoji?! :smiley_ca
 
 For information on the draft for broader practice, see [the draft](./emoji/README.md).
 Perma-URL:
-- Draft [http://emoji.thisco.de/draft/](emoji.thisco.de/draft/)
-- JSON doc [http://emoji.thisco.de/draft/emojimap.json](emoji.thisco.de/draft/emojimap.json)
+- Draft [http://emoji.thisco.de/draft/](http://emoji.thisco.de/draft/)
+- JSON doc [http://emoji.thisco.de/draft/emojimap.json](http://emoji.thisco.de/draft/emojimap.json)
 
 ## build
 


### PR DESCRIPTION
Links did not have a protocol so they were relative, clicking them gave a GH 404 page. Added protocols so that links are now absolute and work correctly.